### PR TITLE
rem function WheeledVehicleData::onAdd(%this, %obj)

### DIFF
--- a/scripts/server/vehicleWheeled.tscript
+++ b/scripts/server/vehicleWheeled.tscript
@@ -29,7 +29,7 @@
 // make it easier for people to simply drop in new (generic) vehicles.  All that
 // the user needs to create is a set of datablocks for the new wheeled vehicle
 // to use.  This means that no (or little) scripting should be necessary.
-
+/* example onadd for vehicle creation referencing additional datablocks
 function WheeledVehicleData::onAdd(%this, %obj)
 {
    Parent::onAdd(%this, %obj);
@@ -50,7 +50,7 @@ function WheeledVehicleData::onAdd(%this, %obj)
    %obj.setWheelPowered(2, true);
    %obj.setWheelPowered(3, true);
 }
-
+*/
 function WheeledVehicleData::onCollision(%this, %obj, %col, %vec, %speed)
 {
    // Collision with other objects, including items


### PR DESCRIPTION
left it in for documentation purposes, but it's use of assumed-existing db defs like DefaultCarTire and DefaultCarSpring that are highly likely to be replaced makes it a *writeup* sample. not an actual *usage* one see CheetahCar::onAdd for one in actual use