### PR TITLE
fix forest brush name

### DIFF
--- a/scripts/managedData/managedForestBrushData.tscript
+++ b/scripts/managedData/managedForestBrushData.tscript
@@ -24,7 +24,7 @@
 // the Forest Editor.
 // This script is executed from ForestEditorPlugin::onWorldEditorStartup().
 
-new SimGroup(ForestBrushGroup) {
+new SimGroup(ExampleForestBrushGroup) {
    canSaveDynamicFields = "1";
 
    new ForestBrush() {


### PR DESCRIPTION
can't use an object name that matches a class, since thse are also namespaces