### PR TITLE
fill in terrain layer particle tinting

### DIFF
--- a/terrains/Example/dirt_grass.asset.taml
+++ b/terrains/Example/dirt_grass.asset.taml
@@ -4,15 +4,19 @@
     VersionId="1">
     <TerrainMaterial
         Name="dirt_grass"
-        DiffuseMapAsset="testMaps:dirt_grass_image"
+        DiffuseMapAsset="@asset=testMaps:dirt_grass_image"
+        DiffuseMapFile="data/testMaps/terrains/Example/dirt_grass.png"
         diffuseSize="200"
-        NormalMapAsset="testMaps:dirt_grass_n_image"
-        DetailMapAsset="testMaps:dirt_grass_d_image"
+        NormalMapAsset="@asset=testMaps:dirt_grass_n_image"
+        NormalMapFile="data/testMaps/terrains/Example/dirt_grass_n.png"
+        DetailMapAsset="@asset=testMaps:dirt_grass_d_image"
+        DetailMapFile="data/testMaps/terrains/Example/dirt_grass_d.png"
         detailSize="4"
-        ORMConfigMapAsset="testMaps:dirt_grass_c_image"
+        ORMConfigMapAsset="@asset=testMaps:dirt_grass_c_image"
+        ORMConfigMapFile="data/testMaps/terrains/Example/dirt_grass_c.png"
         internalName="testMaps:dirt_grass"
         detailBrightness="1"
-        Enabled="1"
+        enabled="1"
         isManaged="1"
         originalAssetName="dirt_grass"/>
     <Material
@@ -25,9 +29,9 @@
         terrainMaterials="1">
         <Material.EffectColors>
             <EffectColor
-                EffectColor="0.42 0.42 0 1"/>
+                EffectColor="0.0511434 0.0835351 0 1"/>
             <EffectColor
-                EffectColor="0.42 0.42 0 1"/>
+                EffectColor="0.222624 0.380056 0 1"/>
         </Material.EffectColors>
     </Material>
 </TerrainMaterialAsset>

--- a/terrains/Example/grassy.asset.taml
+++ b/terrains/Example/grassy.asset.taml
@@ -4,15 +4,19 @@
     VersionId="1">
     <TerrainMaterial
         Name="grassy"
-        DiffuseMapAsset="testMaps:grassy_image"
+        DiffuseMapAsset="@asset=testMaps:grassy_image"
+        DiffuseMapFile="data/testMaps/terrains/Example/grassy.png"
         diffuseSize="200"
-        NormalMapAsset="testMaps:grassy_n_image"
-        DetailMapAsset="testMaps:grassy_d_image"
+        NormalMapAsset="@asset=testMaps:grassy_n_image"
+        NormalMapFile="data/testMaps/terrains/Example/grassy_n.png"
+        DetailMapAsset="@asset=testMaps:grassy_d_image"
+        DetailMapFile="data/testMaps/terrains/Example/grassy_d.png"
         detailSize="4"
-        ORMConfigMapAsset="testMaps:grassy_c_image"
+        ORMConfigMapAsset="@asset=testMaps:grassy_c_image"
+        ORMConfigMapFile="data/testMaps/terrains/Example/grassy_c.png"
         internalName="testMaps:grassy"
         detailBrightness="1"
-        Enabled="1"
+        enabled="1"
         isManaged="1"
         originalAssetName="grassy"/>
     <Material
@@ -25,9 +29,9 @@
         terrainMaterials="1">
         <Material.EffectColors>
             <EffectColor
-                EffectColor="0.42 0.42 0 1"/>
+                EffectColor="0.0511434 0.0835351 0 1"/>
             <EffectColor
-                EffectColor="0.42 0.42 0 1"/>
+                EffectColor="0.222624 0.380056 0 1"/>
         </Material.EffectColors>
     </Material>
 </TerrainMaterialAsset>

--- a/terrains/Example/grassy_dry.asset.taml
+++ b/terrains/Example/grassy_dry.asset.taml
@@ -4,15 +4,19 @@
     VersionId="1">
     <TerrainMaterial
         Name="grassy_dry"
-        DiffuseMapAsset="testMaps:grassy_dry_image"
+        DiffuseMapAsset="@asset=testMaps:grassy_dry_image"
+        DiffuseMapFile="data/testMaps/terrains/Example/grassy_dry.png"
         diffuseSize="200"
-        NormalMapAsset="testMaps:grassy_dry_n_image"
-        DetailMapAsset="testMaps:grassy_dry_d_image"
+        NormalMapAsset="@asset=testMaps:grassy_dry_n_image"
+        NormalMapFile="data/testMaps/terrains/Example/grassy_dry_n.png"
+        DetailMapAsset="@asset=testMaps:grassy_dry_d_image"
+        DetailMapFile="data/testMaps/terrains/Example/grassy_dry_d.png"
         detailSize="4"
-        ORMConfigMapAsset="testMaps:grassy_dry_c_image"
+        ORMConfigMapAsset="@asset=testMaps:grassy_dry_c_image"
+        ORMConfigMapFile="data/testMaps/terrains/Example/grassy_dry_c.png"
         internalName="testMaps:grassy_dry"
         detailBrightness="1"
-        Enabled="1"
+        enabled="1"
         isManaged="1"
         originalAssetName="grassy_dry"/>
     <Material
@@ -25,9 +29,9 @@
         terrainMaterials="1">
         <Material.EffectColors>
             <EffectColor
-                EffectColor="0.42 0.42 0 1"/>
+                EffectColor="0.112805 0.112805 0.112805 1"/>
             <EffectColor
-                EffectColor="0.42 0.42 0 1"/>
+                EffectColor="0.406448 0.406448 0.406448 1"/>
         </Material.EffectColors>
     </Material>
 </TerrainMaterialAsset>

--- a/terrains/Example/rocky.asset.taml
+++ b/terrains/Example/rocky.asset.taml
@@ -29,9 +29,9 @@
         terrainMaterials="1">
         <Material.EffectColors>
             <EffectColor
-                EffectColor="0.42 0.42 0 1"/>
+                EffectColor="0.100482 0.0242977 0 1"/>
             <EffectColor
-                EffectColor="0.42 0.42 0 1"/>
+                EffectColor="0.393123 0.0772627 0 1"/>
         </Material.EffectColors>
     </Material>
 </TerrainMaterialAsset>

--- a/terrains/Example/sandy.asset.taml
+++ b/terrains/Example/sandy.asset.taml
@@ -4,12 +4,16 @@
     VersionId="1">
     <TerrainMaterial
         Name="sandy"
-        DiffuseMapAsset="testMaps:Sandy_b_image"
+        DiffuseMapAsset="@asset=testMaps:Sandy_b_image"
+        DiffuseMapFile="data/testMaps/terrains/Example/Sandy_b.png"
         diffuseSize="200"
-        NormalMapAsset="testMaps:sandy_n_image"
-        DetailMapAsset="testMaps:sandy_d_image"
+        NormalMapAsset="@asset=testMaps:sandy_n_image"
+        NormalMapFile="data/testMaps/terrains/Example/sandy_n.png"
+        DetailMapAsset="@asset=testMaps:sandy_d_image"
+        DetailMapFile="data/testMaps/terrains/Example/sandy_d.png"
         detailSize="2"
-        ORMConfigMapAsset="testMaps:sandy_c_image"
+        ORMConfigMapAsset="@asset=testMaps:sandy_c_image"
+        ORMConfigMapFile="data/testMaps/terrains/Example/sandy_c.png"
         internalName="testMaps:sandy"
         detailBrightness="1"
         enabled="1"
@@ -23,11 +27,15 @@
         impactSoundId="0"
         materialTag0="Terrain"
         terrainMaterials="1">
+        <Material.Stages>
+            <Stages_beginarray
+                DiffuseColor="White"/>
+        </Material.Stages>
         <Material.EffectColors>
             <EffectColor
-                EffectColor="0.42 0.42 0 1"/>
+                EffectColor="0.2957 0.246858 0.121131 1"/>
             <EffectColor
-                EffectColor="0.42 0.42 0 1"/>
+                EffectColor="0.692071 0.585725 0.284101 1"/>
         </Material.EffectColors>
     </Material>
 </TerrainMaterialAsset>

--- a/terrains/Example/stony.asset.taml
+++ b/terrains/Example/stony.asset.taml
@@ -4,12 +4,16 @@
     VersionId="1">
     <TerrainMaterial
         Name="stony"
-        DiffuseMapAsset="testMaps:stony_image"
+        DiffuseMapAsset="@asset=testMaps:stony_image"
+        DiffuseMapFile="data/testMaps/terrains/Example/stony.png"
         diffuseSize="200"
-        NormalMapAsset="testMaps:stony_n_image"
-        DetailMapAsset="testMaps:stony_d_image"
+        NormalMapAsset="@asset=testMaps:stony_n_image"
+        NormalMapFile="data/testMaps/terrains/Example/stony_n.png"
+        DetailMapAsset="@asset=testMaps:stony_d_image"
+        DetailMapFile="data/testMaps/terrains/Example/stony_d.png"
         detailSize="4"
-        ORMConfigMapAsset="testMaps:stony_c_image"
+        ORMConfigMapAsset="@asset=testMaps:stony_c_image"
+        ORMConfigMapFile="data/testMaps/terrains/Example/stony_c.png"
         internalName="testMaps:stony"
         detailBrightness="1"
         enabled="1"
@@ -23,15 +27,11 @@
         impactSoundId="0"
         materialTag0="Terrain"
         terrainMaterials="1">
-        <Material.Stages>
-            <Stages_beginarray
-                DiffuseColor="White"/>
-        </Material.Stages>
         <Material.EffectColors>
             <EffectColor
-                EffectColor="0.42 0.42 0 1"/>
+                EffectColor="0.100482 0.0714935 0.0531058 1"/>
             <EffectColor
-                EffectColor="0.42 0.42 0 1"/>
+                EffectColor="0.330344 0.229208 0.162017 1"/>
         </Material.EffectColors>
     </Material>
 </TerrainMaterialAsset>


### PR DESCRIPTION
effectColor (first and second half) were set to the same value across the board, hiding the ability to tint that on a per material basis (as well as any class features that *should* use them, but aren't doing so properly)